### PR TITLE
Add compiler rules and macros for armv6l and armv7l architectures.

### DIFF
--- a/include/Linux_armv6l/gfortran/Compiler_rules
+++ b/include/Linux_armv6l/gfortran/Compiler_rules
@@ -1,0 +1,37 @@
+define="-DLittle_Endian  -DWITH_gfortran"
+MPI_LIB=""
+MPI_FC="mpif90"
+MPI_F90C="mpif90"
+MPI_CC=mpicc
+FC=${F77C:-gfortran}
+F90C=${F90C:-gfortran}
+CC="cc"
+FC_SHARED="-shared"
+CC_SHARED="-shared"
+Iprefix="-I"
+Lprefix="-L"
+lprefix="-l"
+FC_options=${FC_options:-" -fcray-pointer -fconvert=big-endian -frecord-marker=4 -fno-second-underscore -ffree-line-length-none -fpic ${Iprefix}. ${Iprefix}${ARMNLIB}/include ${Iprefix}${ARMNLIB}/include/${EC_ARCH}"}
+[[ -n $GFORTRAN_RPATH ]] && FC_options="$FC_options  -Wl,-rpath,$GFORTRAN_RPATH"
+FC_LD_options="-Wl,--allow-shlib-undefined"
+OPENMP="-lpthread -fopenmp"
+OPENMPCC="-D_REENTRANT -D_THREAD_SAFE  -lpthread"
+CC_options="-D_REENTRANT -Wtrigraphs -fpic -I. -I${ARMNLIB}/include -I${ARMNLIB}/include/${EC_ARCH} -I."
+CC_LD_options="-Wl,--allow-shlib-undefined"
+F_Opt[0]=-O0
+F_Opt[1]=-O1
+F_Opt[2]=-O2
+F_Opt[3]="-O3"
+F_Opt[4]="-O4"
+O_DEBUG="-g"
+C_Opt[0]=-O0
+C_Opt[1]=-O1
+C_Opt[2]=-O2
+C_Opt[3]=-O2
+C_Opt[4]=-O2
+prof_option="-p"
+
+AR=ar
+VECTOR_LIBS=massvp4_safe
+VECTOR_LIBS_safe=massvp4_safe
+echo Compiler Rules applied for gcc/gfortran

--- a/include/Linux_armv6l/gfortran/rpn_macros_arch.h
+++ b/include/Linux_armv6l/gfortran/rpn_macros_arch.h
@@ -1,0 +1,15 @@
+#define f77name(a) a##_
+#define f77_name(a) a##_
+#define Little_Endian
+#define PTR_AS_INT long long
+#define INT_32 int
+#define INT_64 long long
+#define tell(fdesc) lseek(fdesc,0,1)
+#define FORTRAN_loc_delta           4
+#define wordint INT_32
+#define ftnword INT_32
+#define ftnfloat float
+#define wordfloat float
+#define bytesperword 4
+#define D77MULT            4
+#define F2Cl int

--- a/include/Linux_armv7l
+++ b/include/Linux_armv7l
@@ -1,0 +1,1 @@
+Linux_armv6l


### PR DESCRIPTION
Essentially, I just copied the `Compiler_rules` from `Linux_x86-64/gfortran` and
stripped out the x86-specific flags.

The `rpn_macros_arch.h` is copied verbatim from `Linux_x86-64/gfortran`.

Seems to build everything in the `rmnlib-install` package (with a few patches
to the source codes).  So far I've only tested a few command-line utilties like
`voir` and `r.ip1`.